### PR TITLE
Add DeleteCollection use-case with Qdrant sync and FR workflow doc

### DIFF
--- a/QDRANT_WORKFLOW_FR.md
+++ b/QDRANT_WORKFLOW_FR.md
@@ -1,0 +1,80 @@
+# Rôle de Qdrant et workflow complet dans ce projet
+
+## 1) Rôle de Qdrant
+
+Dans ce projet, **Qdrant est le moteur de recherche vectorielle**. Il est utilisé par `vector-service` pour :
+
+- créer des collections vectorielles ;
+- indexer (upsert) des documents sous forme de points (id, vecteur, payload) ;
+- exécuter des recherches de similarité (`search`) avec score.
+
+Le service applicatif conserve les métadonnées de collection en base relationnelle (Prisma/PostgreSQL), tandis que les vecteurs et la recherche de proximité sont délégués à Qdrant.
+
+## 2) Workflow bout-en-bout
+
+### A. Provisioning et connexion
+
+1. `docker-compose` démarre le conteneur Qdrant (`qdrant/qdrant`) exposé sur `6333` et persiste les données dans un volume.
+2. Au démarrage de `vector-service`, `QdrantClientService` lit `QDRANT_URL` (par défaut `http://qdrant:6333`) et teste la connexion via `getCollections()`.
+
+### B. Création d’une collection
+
+1. `POST /vectors/collections` arrive dans `VectorController`.
+2. `CreateCollectionUseCase` vérifie l’unicité (`name + userId`) côté repository.
+3. La collection logique construit son nom physique Qdrant via `userId_name` (`getQdrantCollectionName`).
+4. Le use-case mappe la distance métier (`cosine`, `euclidean`, `dot`) vers Qdrant (`Cosine`, `Euclid`, `Dot`).
+5. Le client Qdrant appelle `createCollection(...)`.
+6. Les métadonnées de collection sont ensuite enregistrées via Prisma.
+
+### C. Indexation (upsert) de documents
+
+1. `POST /vectors/documents` ou `/vectors/documents/batch`.
+2. Le use-case récupère la collection et valide son existence.
+3. Si l’embedding n’est pas fourni, `EmbeddingService` en génère un (implémentation placeholder actuelle).
+4. Le use-case vérifie la dimension (`embedding.length === collection.dimension`).
+5. Chaque document est converti en point Qdrant (`id`, `vector`, `payload` avec `content`, `metadata`, `createdAt`).
+6. `QdrantClientService.upsertPoints(...)` fait un `upsert` avec `wait: true`.
+
+### D. Recherche de similarité
+
+1. `POST /vectors/search`.
+2. Le use-case récupère la collection et valide la dimension du vecteur requête.
+3. Si besoin, embedding calculé depuis `query`.
+4. Appel `qdrantClient.search(...)` avec `limit` et filtre optionnel.
+5. Le filtre applicatif est transformé en filtre Qdrant via `buildQdrantFilter` (`metadata.<key> = value`).
+6. Retour des résultats mappés (`id`, `score`, `content`, `metadata`).
+
+### E. Suppression
+
+- Le client Qdrant expose bien `deleteCollection`, mais le endpoint `DELETE /vectors/collections/:id` supprime aujourd’hui uniquement la collection dans la base applicative via repository.
+- Il n’y a pas d’appel explicite à `qdrantClient.deleteCollection(...)` dans ce flux.
+
+## 3) Proposition d’optimisation prioritaire
+
+### Problème
+
+Le flux de suppression peut laisser des **collections orphelines dans Qdrant** (fuite de stockage + coût de recherche) car la suppression API ne semble pas synchroniser la suppression côté Qdrant.
+
+### Optimisation recommandée (haute valeur / faible risque)
+
+Implémenter un `DeleteCollectionUseCase` transactionnel applicatif :
+
+1. lire la collection en DB pour récupérer `userId` et `name` ;
+2. calculer le nom Qdrant (`userId_name`) ;
+3. supprimer d’abord dans Qdrant (idempotent: ignorer NotFound) ;
+4. supprimer ensuite la ligne DB ;
+5. journaliser les deux opérations et exposer un statut de cohérence.
+
+### Gains attendus
+
+- pas d’orphelins vectoriels ;
+- cohérence fonctionnelle entre index vectoriel et métadonnées ;
+- meilleure maîtrise des coûts et des performances de recherche.
+
+## 4) Optimisations complémentaires
+
+- **Embeddings réels**: remplacer le placeholder par un provider (OpenAI, bge, e5, etc.) ;
+- **Index tuning Qdrant**: config HNSW/quantization par collection selon volume ;
+- **Batching intelligent**: chunk d’upsert et parallélisme contrôlé pour gros imports ;
+- **Observabilité**: métriques p95/p99 sur latence `upsert/search`, taille de collections, taux d’erreur ;
+- **Lifecycle policy**: archivage/suppression auto de collections inactives.

--- a/services/vector-service/src/app.module.ts
+++ b/services/vector-service/src/app.module.ts
@@ -7,6 +7,7 @@ import { EmbeddingService } from './domain/services/embedding.service';
 import { CreateCollectionUseCase } from './application/use-cases/create-collection.use-case';
 import { UpsertDocumentUseCase } from './application/use-cases/upsert-document.use-case';
 import { SearchSimilarUseCase } from './application/use-cases/search-similar.use-case';
+import { DeleteCollectionUseCase } from './application/use-cases/delete-collection.use-case';
 import { VectorController } from './presentation/controllers/vector.controller';
 import { HealthController } from './presentation/controllers/health.controller';
 
@@ -27,6 +28,7 @@ import { HealthController } from './presentation/controllers/health.controller';
     CreateCollectionUseCase,
     UpsertDocumentUseCase,
     SearchSimilarUseCase,
+    DeleteCollectionUseCase,
   ],
 })
 export class AppModule {}

--- a/services/vector-service/src/application/use-cases/delete-collection.use-case.spec.ts
+++ b/services/vector-service/src/application/use-cases/delete-collection.use-case.spec.ts
@@ -1,0 +1,66 @@
+import { NotFoundException } from '@nestjs/common';
+import { DeleteCollectionUseCase } from './delete-collection.use-case';
+import { Collection } from '../../domain/entities/collection.entity';
+import { IVectorRepository } from '../../domain/repositories/vector.repository.interface';
+import { IQdrantClient } from '../interfaces/qdrant.client.interface';
+
+describe('DeleteCollectionUseCase', () => {
+  const makeCollection = () =>
+    new Collection('col-1', 'knowledge', 'user-1', 384, 'cosine', new Date(), new Date());
+
+  const vectorRepository: jest.Mocked<IVectorRepository> = {
+    createCollection: jest.fn(),
+    findCollectionById: jest.fn(),
+    findCollectionByNameAndUserId: jest.fn(),
+    listCollectionsByUserId: jest.fn(),
+    deleteCollection: jest.fn(),
+  };
+
+  const qdrantClient: jest.Mocked<IQdrantClient> = {
+    createCollection: jest.fn(),
+    deleteCollection: jest.fn(),
+    upsertPoints: jest.fn(),
+    search: jest.fn(),
+    collectionExists: jest.fn(),
+    listCollections: jest.fn(),
+  };
+
+  let useCase: DeleteCollectionUseCase;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCase = new DeleteCollectionUseCase(vectorRepository, qdrantClient);
+  });
+
+  it('throws when the collection is not found', async () => {
+    vectorRepository.findCollectionById.mockResolvedValue(null);
+
+    await expect(useCase.execute('missing')).rejects.toBeInstanceOf(NotFoundException);
+
+    expect(qdrantClient.collectionExists).not.toHaveBeenCalled();
+    expect(vectorRepository.deleteCollection).not.toHaveBeenCalled();
+  });
+
+  it('deletes from Qdrant and metadata storage when collection exists in Qdrant', async () => {
+    const collection = makeCollection();
+    vectorRepository.findCollectionById.mockResolvedValue(collection);
+    qdrantClient.collectionExists.mockResolvedValue(true);
+
+    await useCase.execute(collection.id);
+
+    expect(qdrantClient.collectionExists).toHaveBeenCalledWith('user-1_knowledge');
+    expect(qdrantClient.deleteCollection).toHaveBeenCalledWith('user-1_knowledge');
+    expect(vectorRepository.deleteCollection).toHaveBeenCalledWith('col-1');
+  });
+
+  it('deletes only metadata when Qdrant collection does not exist', async () => {
+    const collection = makeCollection();
+    vectorRepository.findCollectionById.mockResolvedValue(collection);
+    qdrantClient.collectionExists.mockResolvedValue(false);
+
+    await useCase.execute(collection.id);
+
+    expect(qdrantClient.deleteCollection).not.toHaveBeenCalled();
+    expect(vectorRepository.deleteCollection).toHaveBeenCalledWith('col-1');
+  });
+});

--- a/services/vector-service/src/application/use-cases/delete-collection.use-case.ts
+++ b/services/vector-service/src/application/use-cases/delete-collection.use-case.ts
@@ -1,0 +1,37 @@
+import { Injectable, Inject, Logger, NotFoundException } from '@nestjs/common';
+import { IVectorRepository } from '../../domain/repositories/vector.repository.interface';
+import { IQdrantClient } from '../interfaces/qdrant.client.interface';
+
+@Injectable()
+export class DeleteCollectionUseCase {
+  private readonly logger = new Logger(DeleteCollectionUseCase.name);
+
+  constructor(
+    @Inject('IVectorRepository')
+    private readonly vectorRepository: IVectorRepository,
+    @Inject('IQdrantClient')
+    private readonly qdrantClient: IQdrantClient,
+  ) {}
+
+  async execute(collectionId: string): Promise<void> {
+    this.logger.log(`Deleting collection: ${collectionId}`);
+
+    const collection = await this.vectorRepository.findCollectionById(collectionId);
+    if (!collection) {
+      throw new NotFoundException(`Collection '${collectionId}' not found`);
+    }
+
+    const qdrantCollectionName = collection.getQdrantCollectionName();
+    const existsInQdrant = await this.qdrantClient.collectionExists(qdrantCollectionName);
+
+    if (existsInQdrant) {
+      await this.qdrantClient.deleteCollection(qdrantCollectionName);
+      this.logger.log(`Deleted Qdrant collection: ${qdrantCollectionName}`);
+    } else {
+      this.logger.warn(`Qdrant collection does not exist, skipping delete: ${qdrantCollectionName}`);
+    }
+
+    await this.vectorRepository.deleteCollection(collectionId);
+    this.logger.log(`Deleted collection metadata: ${collectionId}`);
+  }
+}

--- a/services/vector-service/src/infrastructure/persistence/vector.repository.ts
+++ b/services/vector-service/src/infrastructure/persistence/vector.repository.ts
@@ -96,7 +96,7 @@ export class VectorRepository implements IVectorRepository {
 
     return {
       data: records.map(
-        (c) =>
+        (c: { id: string; name: string; userId: string; dimension: number; createdAt: Date; updatedAt: Date }) =>
           new Collection(c.id, c.name, c.userId, c.dimension, 'cosine', c.createdAt, c.updatedAt),
       ),
       total,

--- a/services/vector-service/src/presentation/controllers/vector.controller.ts
+++ b/services/vector-service/src/presentation/controllers/vector.controller.ts
@@ -13,6 +13,7 @@ import {
 import { CreateCollectionUseCase } from '../../application/use-cases/create-collection.use-case';
 import { UpsertDocumentUseCase } from '../../application/use-cases/upsert-document.use-case';
 import { SearchSimilarUseCase } from '../../application/use-cases/search-similar.use-case';
+import { DeleteCollectionUseCase } from '../../application/use-cases/delete-collection.use-case';
 import { CreateCollectionDto } from '../../application/dto/create-collection.dto';
 import { UpsertDocumentDto, UpsertDocumentsDto } from '../../application/dto/upsert-document.dto';
 import { SearchDto } from '../../application/dto/search.dto';
@@ -27,6 +28,7 @@ export class VectorController {
     private readonly createCollectionUseCase: CreateCollectionUseCase,
     private readonly upsertDocumentUseCase: UpsertDocumentUseCase,
     private readonly searchSimilarUseCase: SearchSimilarUseCase,
+    private readonly deleteCollectionUseCase: DeleteCollectionUseCase,
     @Inject('IVectorRepository')
     private readonly vectorRepository: IVectorRepository,
   ) {}
@@ -99,7 +101,7 @@ export class VectorController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteCollection(@Param('id') id: string) {
     this.logger.log(`DELETE /vectors/collections/${id} - Deleting collection`);
-    await this.vectorRepository.deleteCollection(id);
+    await this.deleteCollectionUseCase.execute(id);
   }
 
   @Post('documents')


### PR DESCRIPTION
### Motivation

- Prevent orphaned collections in Qdrant by ensuring deletions synchronize the vector index and metadata.  
- Encapsulate deletion logic into an application use-case to centralize Qdrant interaction and logging.  
- Document the Qdrant role and end-to-end workflow in French for developer onboarding and operations.  

### Description

- Added `DeleteCollectionUseCase` which looks up collection metadata, checks existence in Qdrant via `collectionExists`, deletes the Qdrant collection when present, and then deletes the metadata via `IVectorRepository`.  
- Wired the use-case into the application by registering `DeleteCollectionUseCase` in `AppModule` and injecting it into `VectorController`; the `DELETE /vectors/collections/:id` endpoint now calls `DeleteCollectionUseCase.execute`.  
- Added unit tests in `delete-collection.use-case.spec.ts` covering not-found behavior, deletion when Qdrant collection exists, and metadata-only deletion when it does not.  
- Added `QDRANT_WORKFLOW_FR.md` documenting Qdrant responsibilities, end-to-end flows, recommended optimizations, and the deletion consistency issue; applied a small typing/mapper cleanup in `vector.repository.ts`.  

### Testing

- Added Jest unit tests for `DeleteCollectionUseCase` (`delete-collection.use-case.spec.ts`) exercising the three main scenarios and verified they pass.  
- Ran the new unit tests with the test runner (`jest`) and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a00483c19c8329b2e7e0847e3a5e8c)